### PR TITLE
Code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -26,7 +26,88 @@ luarocks-5.2 install luacrypto 0.3.2-2 OPENSSL_INCDIR=/usr/local/Cellar/openssl/
 luarocks-5.2 install date 2.1.1-1
 ```
 
+Examples
+-----
 
+Authentication:
+```lua
+local escher = Escher({
+    algoPrefix = "AWS4",
+    vendorKey = "AWS4",
+    hashAlgo = "SHA256",
+    credentialScope = "us-east-1/host/aws4_request",
+    authHeaderName = "X-EMS-Auth",
+    dateHeaderName = "X-EMS-Date",
+    date = "2011-09-09T23:36:00.000Z" -- give date for testing purposes only
+})
+
+local request = {
+    method = "GET",
+    url = "/",
+    headers = {
+        { "X-EMS-Date", "20110909T233600Z" },
+        { "Host", "host.foo.com" },
+        { "X-EMS-Auth", "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=x-ems-date;host, Signature=3a2b15801d517d0010be640f0685fa60b5d793396be38e0566ede3d334554479" }
+    },
+    body = ""
+}
+
+local my_key = "AKIDEXAMPLE"
+
+local function keyDb(key)
+    if key == my_key then
+        return "1/K7MDENG+bPxRfiCYEXAMPLEKEY"
+    end
+end
+
+local headersToSign = { "x-ems-date" }
+
+local auth_key = escher:authenticate(request, keyDb, headersToSign)
+
+assert(auth_key == my_key, "Auth key mismatch") -- should not throw error
+```
+
+Signing a request:
+```lua
+local escher = Escher({
+    algoPrefix = "AWS4",
+    vendorKey = "AWS4",
+    hashAlgo = "SHA256",
+    credentialScope = "us-east-1/host/aws4_request",
+    authHeaderName = "X-EMS-Auth",
+    dateHeaderName = "X-EMS-Date",
+    date = "2011-09-09T23:36:00.000Z", -- give date for testing purposes only
+    apiSecret = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+    accessKeyId = "AKIDEXAMPLE"
+})
+
+local request = {
+    method = "GET",
+    url = "/",
+    headers = {
+        { "Host", "host.foo.com" }
+    },
+    body = ""
+}
+
+local headersToSign = { "x-ems-date" }
+
+escher:signRequest(request, headersToSign)
+
+--[[
+request should now look like this:
+{
+    body = "",
+    method = "GET",
+    url = "/",
+    headers = {
+        { "Host", "host.foo.com" },
+        { "X-EMS-Date", "Fri, 09 Sep 2011 23:36:00 GMT" },
+        { "X-EMS-Auth", "..." }
+    }
+}
+--]]
+```
 
 Run the tests
 -------------

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ luarocks-5.2 install date 2.1.1-1
 ```
 
 Examples
------
+-------------
 
 Authentication:
 ```lua

--- a/escher-0.2-17.rockspec
+++ b/escher-0.2-17.rockspec
@@ -20,6 +20,8 @@ build = {
     type = "builtin",
     modules = {
         ["escher"] = "src/escher.lua",
+        ["escher.canonicalizer"] = "src/escher/canonicalizer.lua",
         ["escher.urlhandler"] = "src/escher/urlhandler.lua",
+        ["escher.utils"] = "src/escher/utils.lua"
     }
 }

--- a/escher-0.2-17.rockspec
+++ b/escher-0.2-17.rockspec
@@ -21,6 +21,7 @@ build = {
     modules = {
         ["escher"] = "src/escher.lua",
         ["escher.canonicalizer"] = "src/escher/canonicalizer.lua",
+        ["escher.signer"] = "src/escher/signer.lua",
         ["escher.urlhandler"] = "src/escher/urlhandler.lua",
         ["escher.utils"] = "src/escher/utils.lua"
     }

--- a/spec/empty_spec.lua
+++ b/spec/empty_spec.lua
@@ -3,7 +3,7 @@ describe("Empty test", function()
   describe("should work", function()
 
     it("should end with success", function()
-      assert.True(2*2 == 4)
+      assert.True(2 * 2 == 4)
     end)
 
   end)

--- a/spec/escher_unit_spec.lua
+++ b/spec/escher_unit_spec.lua
@@ -78,6 +78,44 @@ describe("Escher", function()
             assert.are.same({ "x-ems-date" }, headersToSign)
         end)
 
+        context("when URL is pre-signed", function()
+
+            it("should not mutate passed in parameters", function()
+                local escher = Escher:new({
+                    algoPrefix = "EMS",
+                    vendorKey = "EMS",
+                    hashAlgo = "SHA256",
+                    credentialScope = "us-east-1/host/aws4_request",
+                    date = "2011-05-11T12:00:00.000Z"
+                })
+                local request = {
+                    method = "GET",
+                    url = "/something?foo=bar&baz=barbaz&X-EMS-Algorithm=EMS-HMAC-SHA256&X-EMS-Credentials=th3K3y%2F20110511%2Fus-east-1%2Fhost%2Faws4_request&X-EMS-Date=20110511T120000Z&X-EMS-Expires=123456&X-EMS-SignedHeaders=host&X-EMS-Signature=fbc9dbb91670e84d04ad2ae7505f4f52ab3ff9e192b8233feeae57e9022c2b67",
+                    headers = {
+                        { "Host", "example.com" }
+                    },
+                    body = ""
+                }
+                local function keyDb()
+                    return "very_secure"
+                end
+                local headersToSign = {}
+
+                escher:authenticate(request, keyDb, headersToSign)
+
+                assert.are.same({
+                    method = "GET",
+                    url = "/something?foo=bar&baz=barbaz&X-EMS-Algorithm=EMS-HMAC-SHA256&X-EMS-Credentials=th3K3y%2F20110511%2Fus-east-1%2Fhost%2Faws4_request&X-EMS-Date=20110511T120000Z&X-EMS-Expires=123456&X-EMS-SignedHeaders=host&X-EMS-Signature=fbc9dbb91670e84d04ad2ae7505f4f52ab3ff9e192b8233feeae57e9022c2b67",
+                    headers = {
+                        { "Host", "example.com" }
+                    },
+                    body = ""
+                }, request)
+                assert.are.same({}, headersToSign)
+            end)
+
+        end)
+
     end)
 
 end)

--- a/spec/escher_unit_spec.lua
+++ b/spec/escher_unit_spec.lua
@@ -36,4 +36,48 @@ describe("Escher", function()
 
     end)
 
+    describe("#authenticate", function()
+
+        it("should not mutate passed in parameters", function()
+            local escher = Escher:new({
+                algoPrefix = "AWS4",
+                vendorKey = "AWS4",
+                hashAlgo = "SHA256",
+                credentialScope = "us-east-1/host/aws4_request",
+                authHeaderName = "X-EMS-Auth",
+                dateHeaderName = "X-EMS-Date",
+                date = "2011-09-09T23:36:00.000Z"
+            })
+            local request = {
+                method = "GET",
+                url = "/",
+                headers = {
+                    { "X-EMS-Date", "20110909T233600Z" },
+                    { "Host", "host.foo.com" },
+                    { "X-EMS-Auth", "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=x-ems-date;host, Signature=3a2b15801d517d0010be640f0685fa60b5d793396be38e0566ede3d334554479" }
+                },
+                body = ""
+            }
+            local function keyDb()
+                return "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+            end
+            local headersToSign = { "x-ems-date" }
+
+            escher:authenticate(request, keyDb, headersToSign)
+
+            assert.are.same({
+                method = "GET",
+                url = "/",
+                headers = {
+                    { "X-EMS-Date", "20110909T233600Z" },
+                    { "Host", "host.foo.com" },
+                    { "X-EMS-Auth", "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=x-ems-date;host, Signature=3a2b15801d517d0010be640f0685fa60b5d793396be38e0566ede3d334554479" }
+                },
+                body = ""
+            }, request)
+            assert.are.same({ "x-ems-date" }, headersToSign)
+        end)
+
+    end)
+
 end)

--- a/spec/escher_unit_spec.lua
+++ b/spec/escher_unit_spec.lua
@@ -1,0 +1,39 @@
+local Escher = require("escher")
+
+describe("Escher", function()
+
+    describe("#new", function()
+
+        it("should not mutate passed in parameters", function()
+            local options = {
+                algoPrefix = "AWS4",
+                vendorKey = "AWS4",
+                hashAlgo = "SHA256",
+                apiSecret = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+                accessKeyId = "AKIDEXAMPLE",
+                credentialScope = "my/custom/scope",
+                authHeaderName = "X-EMS-Auth",
+                dateHeaderName = "X-EMS-Date",
+                date = "2019-01-10T20:25:00.000Z",
+                clockSkew = 300
+            }
+            local escher = Escher:new(options)
+
+            assert.are.Not.equals(options, escher)
+            assert.are.same({
+                algoPrefix = "AWS4",
+                vendorKey = "AWS4",
+                hashAlgo = "SHA256",
+                apiSecret = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+                accessKeyId = "AKIDEXAMPLE",
+                credentialScope = "my/custom/scope",
+                authHeaderName = "X-EMS-Auth",
+                dateHeaderName = "X-EMS-Date",
+                date = "2019-01-10T20:25:00.000Z",
+                clockSkew = 300
+            }, options)
+        end)
+
+    end)
+
+end)

--- a/spec/escher_unit_spec.lua
+++ b/spec/escher_unit_spec.lua
@@ -37,6 +37,30 @@ describe("Escher", function()
 
     end)
 
+    describe("constructor", function()
+
+        it("should create an Escher instance", function()
+            local options = {
+                algoPrefix = "AWS4",
+                vendorKey = "AWS4",
+                hashAlgo = "SHA256",
+                apiSecret = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+                accessKeyId = "AKIDEXAMPLE",
+                credentialScope = "my/custom/scope",
+                authHeaderName = "X-EMS-Auth",
+                dateHeaderName = "X-EMS-Date",
+                date = "2019-01-10T20:25:00.000Z",
+                clockSkew = 300
+            }
+
+            assert.are.same(
+                Escher:new(options),
+                Escher(options)
+            )
+        end)
+
+    end)
+
     describe("#authenticate", function()
 
         it("should not mutate passed in parameters", function()

--- a/spec/escher_unit_spec.lua
+++ b/spec/escher_unit_spec.lua
@@ -17,6 +17,7 @@ describe("Escher", function()
                 date = "2019-01-10T20:25:00.000Z",
                 clockSkew = 300
             }
+
             local escher = Escher:new(options)
 
             assert.are.Not.equals(options, escher)
@@ -48,6 +49,7 @@ describe("Escher", function()
                 dateHeaderName = "X-EMS-Date",
                 date = "2011-09-09T23:36:00.000Z"
             })
+
             local request = {
                 method = "GET",
                 url = "/",
@@ -58,9 +60,11 @@ describe("Escher", function()
                 },
                 body = ""
             }
+
             local function keyDb()
                 return "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
             end
+
             local headersToSign = { "x-ems-date" }
 
             escher:authenticate(request, keyDb, headersToSign)
@@ -88,6 +92,7 @@ describe("Escher", function()
                     credentialScope = "us-east-1/host/aws4_request",
                     date = "2011-05-11T12:00:00.000Z"
                 })
+
                 local request = {
                     method = "GET",
                     url = "/something?foo=bar&baz=barbaz&X-EMS-Algorithm=EMS-HMAC-SHA256&X-EMS-Credentials=th3K3y%2F20110511%2Fus-east-1%2Fhost%2Faws4_request&X-EMS-Date=20110511T120000Z&X-EMS-Expires=123456&X-EMS-SignedHeaders=host&X-EMS-Signature=fbc9dbb91670e84d04ad2ae7505f4f52ab3ff9e192b8233feeae57e9022c2b67",
@@ -96,9 +101,11 @@ describe("Escher", function()
                     },
                     body = ""
                 }
+
                 local function keyDb()
                     return "very_secure"
                 end
+
                 local headersToSign = {}
 
                 escher:authenticate(request, keyDb, headersToSign)
@@ -114,6 +121,46 @@ describe("Escher", function()
                 assert.are.same({}, headersToSign)
             end)
 
+        end)
+
+    end)
+
+    describe("#generateHeader", function()
+
+        it("should not mutate passed in parameters", function()
+            local escher = Escher:new({
+                algoPrefix = "AWS4",
+                vendorKey = "AWS4",
+                hashAlgo = "SHA256",
+                credentialScope = "us-east-1/host/aws4_request",
+                authHeaderName = "X-EMS-Auth",
+                dateHeaderName = "X-EMS-Date",
+                date = "2011-09-09T23:36:00.000Z",
+                apiSecret = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+                accessKeyId = "AKIDEXAMPLE"
+            })
+
+            local request = {
+                method = "GET",
+                url = "/",
+                headers = {
+                    { "Host", "host.foo.com" }
+                },
+                body = ""
+            }
+
+            local headersToSign = { "x-ems-date" }
+
+            local authHeader = escher:generateHeader(request, headersToSign)
+
+            assert.are.same({
+                method = "GET",
+                url = "/",
+                headers = {
+                    { "Host", "host.foo.com" }
+                },
+                body = ""
+            }, request)
         end)
 
     end)

--- a/spec/escher_unit_spec.lua
+++ b/spec/escher_unit_spec.lua
@@ -175,7 +175,7 @@ describe("Escher", function()
 
             local headersToSign = { "x-ems-date" }
 
-            local authHeader = escher:generateHeader(request, headersToSign)
+            escher:generateHeader(request, headersToSign)
 
             assert.are.same({
                 method = "GET",

--- a/spec/testsuite_spec.lua
+++ b/spec/testsuite_spec.lua
@@ -1,7 +1,8 @@
 local json = require("rapidjson")
-local Escher = require("escher")
 local socketUrl = require("socket.url")
 local date = require("date")
+local Escher = require("escher")
+local Canonicalizer = require("escher.canonicalizer")
 
 local function readTest(filename)
   local f = io.open(filename, "r")
@@ -111,6 +112,25 @@ local function runTestFiles(group, fn)
   end
 end
 
+describe("Canonicalizer TestSuite", function()
+
+  describe("canonicalizeRequest", function()
+
+    runTestFiles("signing", function(testFile, test)
+      it("should canonicalize the request " .. testFile, function()
+        local canonicalizer = Canonicalizer:new(getConfigFromTestsuite(test.config))
+        local canonicalizedRequest = canonicalizer:canonicalizeRequest(test.request, test.headersToSign)
+
+        if test.expected.canonicalizedRequest then
+          assert.are.equals(test.expected.canonicalizedRequest, canonicalizedRequest)
+        end
+      end)
+    end)
+
+  end)
+
+end)
+
 describe("Escher TestSuite", function()
 
   describe("load 'GET vanilla' JSON", function()
@@ -119,21 +139,6 @@ describe("Escher TestSuite", function()
       local test = readTest("spec/aws4_testsuite/signrequest-get-vanilla.json")
 
       assert.are.equals(test.request.method, "GET")
-    end)
-
-  end)
-
-  describe("canonicalizeRequest", function()
-
-    runTestFiles("signing", function(testFile, test)
-      it("should canonicalize the request " .. testFile, function()
-        local escher = Escher:new(getConfigFromTestsuite(test.config))
-        local canonicalizedRequest = escher:canonicalizeRequest(test.request, test.headersToSign)
-
-        if test.expected.canonicalizedRequest then
-          assert.are.equals(test.expected.canonicalizedRequest, canonicalizedRequest)
-        end
-      end)
     end)
 
   end)

--- a/spec/testsuite_spec.lua
+++ b/spec/testsuite_spec.lua
@@ -3,6 +3,7 @@ local socketUrl = require("socket.url")
 local date = require("date")
 local Escher = require("escher")
 local Canonicalizer = require("escher.canonicalizer")
+local Signer = require("escher.signer")
 
 local function readTest(filename)
   local f = io.open(filename, "r")
@@ -131,6 +132,27 @@ describe("Canonicalizer TestSuite", function()
 
 end)
 
+describe("Signer TestSuite", function()
+
+  describe("getStringToSign", function()
+
+    runTestFiles("signing", function(testFile, test)
+      it("should return the proper string to sign " .. testFile, function()
+        local config = getConfigFromTestsuite(test.config)
+        local signer = Signer:new(config)
+        local date, secret = date(config.date), config.apiSecret
+        local stringToSign = signer:getStringToSign(test.request, test.headersToSign, date, secret)
+
+        if test.expected.stringToSign then
+          assert.are.equals(test.expected.stringToSign, stringToSign)
+        end
+      end)
+    end)
+
+  end)
+
+end)
+
 describe("Escher TestSuite", function()
 
   describe("load 'GET vanilla' JSON", function()
@@ -139,21 +161,6 @@ describe("Escher TestSuite", function()
       local test = readTest("spec/aws4_testsuite/signrequest-get-vanilla.json")
 
       assert.are.equals(test.request.method, "GET")
-    end)
-
-  end)
-
-  describe("getStringToSign", function()
-
-    runTestFiles("signing", function(testFile, test)
-      it("should return the proper string to sign " .. testFile, function()
-        local escher = Escher:new(getConfigFromTestsuite(test.config))
-        local stringToSign = escher:getStringToSign(test.request, test.headersToSign)
-
-        if test.expected.stringToSign then
-          assert.are.equals(test.expected.stringToSign, stringToSign)
-        end
-      end)
     end)
 
   end)

--- a/spec/testsuite_spec.lua
+++ b/spec/testsuite_spec.lua
@@ -26,80 +26,80 @@ end
 local function runTestFiles(group, fn)
   testFiles = {
     signing = {
-      'spec/aws4_testsuite/signrequest-get-vanilla.json',
-      'spec/aws4_testsuite/signrequest-post-vanilla.json',
-      'spec/aws4_testsuite/signrequest-get-vanilla-query.json',
-      'spec/aws4_testsuite/signrequest-post-vanilla-query.json',
-      'spec/aws4_testsuite/signrequest-get-vanilla-empty-query-key.json',
-      'spec/aws4_testsuite/signrequest-post-vanilla-empty-query-value.json',
-      'spec/aws4_testsuite/signrequest-get-vanilla-query-order-key.json',
-      'spec/aws4_testsuite/signrequest-post-x-www-form-urlencoded.json',
-      'spec/aws4_testsuite/signrequest-post-x-www-form-urlencoded-parameters.json',
-      'spec/aws4_testsuite/signrequest-get-header-value-trim.json',
-      'spec/aws4_testsuite/signrequest-post-header-key-case.json',
-      'spec/aws4_testsuite/signrequest-post-header-key-sort.json',
-      'spec/aws4_testsuite/signrequest-post-header-value-case.json',
-      'spec/aws4_testsuite/signrequest-get-vanilla-query-order-value.json',
-      'spec/aws4_testsuite/signrequest-get-vanilla-query-order-key-case.json',
-      'spec/aws4_testsuite/signrequest-get-unreserved.json',
-      'spec/aws4_testsuite/signrequest-get-vanilla-query-unreserved.json',
-      'spec/aws4_testsuite/signrequest-get-vanilla-ut8-query.json',
-      'spec/aws4_testsuite/signrequest-get-utf8.json',
-      'spec/aws4_testsuite/signrequest-get-space.json',
-      'spec/aws4_testsuite/signrequest-post-vanilla-query-space.json',
-      'spec/aws4_testsuite/signrequest-post-vanilla-query-nonunreserved.json',
-      'spec/aws4_testsuite/signrequest-get-slash.json',
-      'spec/aws4_testsuite/signrequest-get-slashes.json',
-      'spec/aws4_testsuite/signrequest-get-slash-dot-slash.json',
-      'spec/aws4_testsuite/signrequest-get-slash-pointless-dot.json',
-      'spec/aws4_testsuite/signrequest-get-relative.json',
-      'spec/aws4_testsuite/signrequest-get-relative-relative.json',
-      'spec/emarsys_testsuite/signrequest-get-header-key-duplicate.json',
-      'spec/emarsys_testsuite/signrequest-get-header-value-order.json',
-      'spec/emarsys_testsuite/signrequest-post-header-key-order.json',
-      'spec/emarsys_testsuite/signrequest-post-header-value-spaces.json',
-      'spec/emarsys_testsuite/signrequest-post-header-value-spaces-within-quotes.json',
-      'spec/emarsys_testsuite/signrequest-post-payload-utf8.json',
-      'spec/emarsys_testsuite/signrequest-date-header-should-be-signed-headers.json',
-      'spec/emarsys_testsuite/signrequest-only-sign-specified-headers.json',
-      'spec/emarsys_testsuite/signrequest-support-custom-config.json',
-      'spec/emarsys_testsuite/signrequest-support-custom-config-with-customer-id.json'
+      "spec/aws4_testsuite/signrequest-get-vanilla.json",
+      "spec/aws4_testsuite/signrequest-post-vanilla.json",
+      "spec/aws4_testsuite/signrequest-get-vanilla-query.json",
+      "spec/aws4_testsuite/signrequest-post-vanilla-query.json",
+      "spec/aws4_testsuite/signrequest-get-vanilla-empty-query-key.json",
+      "spec/aws4_testsuite/signrequest-post-vanilla-empty-query-value.json",
+      "spec/aws4_testsuite/signrequest-get-vanilla-query-order-key.json",
+      "spec/aws4_testsuite/signrequest-post-x-www-form-urlencoded.json",
+      "spec/aws4_testsuite/signrequest-post-x-www-form-urlencoded-parameters.json",
+      "spec/aws4_testsuite/signrequest-get-header-value-trim.json",
+      "spec/aws4_testsuite/signrequest-post-header-key-case.json",
+      "spec/aws4_testsuite/signrequest-post-header-key-sort.json",
+      "spec/aws4_testsuite/signrequest-post-header-value-case.json",
+      "spec/aws4_testsuite/signrequest-get-vanilla-query-order-value.json",
+      "spec/aws4_testsuite/signrequest-get-vanilla-query-order-key-case.json",
+      "spec/aws4_testsuite/signrequest-get-unreserved.json",
+      "spec/aws4_testsuite/signrequest-get-vanilla-query-unreserved.json",
+      "spec/aws4_testsuite/signrequest-get-vanilla-ut8-query.json",
+      "spec/aws4_testsuite/signrequest-get-utf8.json",
+      "spec/aws4_testsuite/signrequest-get-space.json",
+      "spec/aws4_testsuite/signrequest-post-vanilla-query-space.json",
+      "spec/aws4_testsuite/signrequest-post-vanilla-query-nonunreserved.json",
+      "spec/aws4_testsuite/signrequest-get-slash.json",
+      "spec/aws4_testsuite/signrequest-get-slashes.json",
+      "spec/aws4_testsuite/signrequest-get-slash-dot-slash.json",
+      "spec/aws4_testsuite/signrequest-get-slash-pointless-dot.json",
+      "spec/aws4_testsuite/signrequest-get-relative.json",
+      "spec/aws4_testsuite/signrequest-get-relative-relative.json",
+      "spec/emarsys_testsuite/signrequest-get-header-key-duplicate.json",
+      "spec/emarsys_testsuite/signrequest-get-header-value-order.json",
+      "spec/emarsys_testsuite/signrequest-post-header-key-order.json",
+      "spec/emarsys_testsuite/signrequest-post-header-value-spaces.json",
+      "spec/emarsys_testsuite/signrequest-post-header-value-spaces-within-quotes.json",
+      "spec/emarsys_testsuite/signrequest-post-payload-utf8.json",
+      "spec/emarsys_testsuite/signrequest-date-header-should-be-signed-headers.json",
+      "spec/emarsys_testsuite/signrequest-only-sign-specified-headers.json",
+      "spec/emarsys_testsuite/signrequest-support-custom-config.json",
+      "spec/emarsys_testsuite/signrequest-support-custom-config-with-customer-id.json"
     },
     validation = {
-      'spec/emarsys_testsuite/authenticate-error-date-header-auth-header-date-not-equal.json',
-      'spec/emarsys_testsuite/authenticate-error-date-header-not-signed.json',
-      'spec/emarsys_testsuite/authenticate-error-host-header-not-signed.json',
-      'spec/emarsys_testsuite/authenticate-error-invalid-auth-header.json',
-      'spec/emarsys_testsuite/authenticate-error-invalid-credential-scope.json',
-      'spec/emarsys_testsuite/authenticate-error-invalid-escher-key.json',
-      'spec/emarsys_testsuite/authenticate-error-invalid-hash-algorithm.json',
-      'spec/emarsys_testsuite/authenticate-error-missing-auth-header.json',
-      'spec/emarsys_testsuite/authenticate-error-missing-date-header.json',
-      'spec/emarsys_testsuite/authenticate-error-missing-host-header.json',
-      'spec/emarsys_testsuite/authenticate-error-presigned-url-expired.json',
-      'spec/emarsys_testsuite/authenticate-error-request-date-invalid.json',
-      'spec/emarsys_testsuite/authenticate-error-wrong-signature.json',
-      'spec/emarsys_testsuite/authenticate-valid-authentication-datein-expiretime.json',
-      'spec/emarsys_testsuite/authenticate-valid-get-vanilla-empty-query-with-custom-headernames.json',
-      'spec/emarsys_testsuite/authenticate-valid-get-vanilla-empty-query.json',
-      'spec/emarsys_testsuite/authenticate-valid-ignore-headers-order.json',
-      'spec/emarsys_testsuite/authenticate-valid-presigned-url-with-query.json',
-      'spec/emarsys_testsuite/authenticate-valid-presigned-double-url-encoded.json',
-      'spec/emarsys_testsuite/authenticate-valid-credential-with-spaces.json',
-      'spec/emarsys_testsuite/authenticate-error-mandatoryheaders-not-array-of-strings.json',
-      'spec/emarsys_testsuite/authenticate-error-mandatoryheaders-not-array.json',
-      'spec/emarsys_testsuite/authenticate-error-notsigned-header.json',
-      'spec/emarsys_testsuite/authenticate-error-get-uppercase-signed-header.json'
+      "spec/emarsys_testsuite/authenticate-error-date-header-auth-header-date-not-equal.json",
+      "spec/emarsys_testsuite/authenticate-error-date-header-not-signed.json",
+      "spec/emarsys_testsuite/authenticate-error-host-header-not-signed.json",
+      "spec/emarsys_testsuite/authenticate-error-invalid-auth-header.json",
+      "spec/emarsys_testsuite/authenticate-error-invalid-credential-scope.json",
+      "spec/emarsys_testsuite/authenticate-error-invalid-escher-key.json",
+      "spec/emarsys_testsuite/authenticate-error-invalid-hash-algorithm.json",
+      "spec/emarsys_testsuite/authenticate-error-missing-auth-header.json",
+      "spec/emarsys_testsuite/authenticate-error-missing-date-header.json",
+      "spec/emarsys_testsuite/authenticate-error-missing-host-header.json",
+      "spec/emarsys_testsuite/authenticate-error-presigned-url-expired.json",
+      "spec/emarsys_testsuite/authenticate-error-request-date-invalid.json",
+      "spec/emarsys_testsuite/authenticate-error-wrong-signature.json",
+      "spec/emarsys_testsuite/authenticate-valid-authentication-datein-expiretime.json",
+      "spec/emarsys_testsuite/authenticate-valid-get-vanilla-empty-query-with-custom-headernames.json",
+      "spec/emarsys_testsuite/authenticate-valid-get-vanilla-empty-query.json",
+      "spec/emarsys_testsuite/authenticate-valid-ignore-headers-order.json",
+      "spec/emarsys_testsuite/authenticate-valid-presigned-url-with-query.json",
+      "spec/emarsys_testsuite/authenticate-valid-presigned-double-url-encoded.json",
+      "spec/emarsys_testsuite/authenticate-valid-credential-with-spaces.json",
+      "spec/emarsys_testsuite/authenticate-error-mandatoryheaders-not-array-of-strings.json",
+      "spec/emarsys_testsuite/authenticate-error-mandatoryheaders-not-array.json",
+      "spec/emarsys_testsuite/authenticate-error-notsigned-header.json",
+      "spec/emarsys_testsuite/authenticate-error-get-uppercase-signed-header.json"
     },
     generateSignedUrl = {
-      'spec/emarsys_testsuite/presignurl-valid-with-path-query.json',
-      'spec/emarsys_testsuite/presignurl-valid-with-port.json',
-      'spec/emarsys_testsuite/presignurl-valid-with-hash.json',
-      'spec/emarsys_testsuite/presignurl-valid-with-URL-encoded-array-parameters.json',
-      'spec/emarsys_testsuite/presignurl-valid-with-double-url-encoded.json'
+      "spec/emarsys_testsuite/presignurl-valid-with-path-query.json",
+      "spec/emarsys_testsuite/presignurl-valid-with-port.json",
+      "spec/emarsys_testsuite/presignurl-valid-with-hash.json",
+      "spec/emarsys_testsuite/presignurl-valid-with-URL-encoded-array-parameters.json",
+      "spec/emarsys_testsuite/presignurl-valid-with-double-url-encoded.json"
     },
     generateAndAuthenticate = {
-      'spec/emarsys_testsuite/authenticate-valid-with-generating-presigned-url-with-query.json',
+      "spec/emarsys_testsuite/authenticate-valid-with-generating-presigned-url-with-query.json",
     }
   }
   for _, testFile in pairs(testFiles[group]) do
@@ -109,16 +109,16 @@ end
 
 describe("Escher TestSuite", function()
 
-  describe('load "GET vanilla" JSON', function()
+  describe("load 'GET vanilla' JSON", function()
 
     it("should properly loaded", function()
-      test = readTest('spec/aws4_testsuite/signrequest-get-vanilla.json')
+      test = readTest("spec/aws4_testsuite/signrequest-get-vanilla.json")
       assert.are.equals(test.request.method, "GET")
     end)
 
   end)
 
-  describe('canonicalizeRequest', function()
+  describe("canonicalizeRequest", function()
 
     runTestFiles("signing", function(testFile, test)
       it("should canonicalize the request " .. testFile, function()
@@ -133,7 +133,7 @@ describe("Escher TestSuite", function()
 
   end)
 
-  describe('getStringToSign', function()
+  describe("getStringToSign", function()
 
     runTestFiles("signing", function(testFile, test)
       it("should return the proper string to sign " .. testFile, function()
@@ -148,13 +148,13 @@ describe("Escher TestSuite", function()
 
   end)
 
-  describe('signRequest', function()
+  describe("signRequest", function()
 
     runTestFiles("signing", function(testFile, test)
       it("should generate full authorization header " .. testFile, function()
         local escher = Escher:new(getConfigFromTestsuite(test.config))
         test.request = escher:signRequest(test.request, test.headersToSign)
-        local authHeader = ''
+        local authHeader = ""
 
         for _, element in ipairs(test.request.headers) do
           if element[1] == test.config.authHeaderName then
@@ -170,7 +170,7 @@ describe("Escher TestSuite", function()
   end)
 
 
-  describe('generatePreSignedUrl', function()
+  describe("generatePreSignedUrl", function()
 
     runTestFiles("generateSignedUrl", function(testFile, test)
       it("should return the proper url string" .. testFile, function()
@@ -186,7 +186,7 @@ describe("Escher TestSuite", function()
 
   end)
 
-  describe('authenticateRequest', function()
+  describe("authenticateRequest", function()
 
     runTestFiles("validation", function(testFile, test)
       it("should validate the request " .. testFile, function()
@@ -215,26 +215,26 @@ describe("Escher TestSuite", function()
 
   local function createRequestFromUrl(url)
     local parsedUrl = socketUrl.parse(url)
-    local buildedUrl = ''
+    local buildedUrl = ""
     local enableBuild = false
 
     for _,v in ipairs(socketUrl.parse_path(url)) do
       if enableBuild then
-        buildedUrl = buildedUrl .. '/' .. v
+        buildedUrl = buildedUrl .. "/" .. v
       elseif string.find(v, parsedUrl.host) ~= nil then
         enableBuild = true
       end
     end
 
     return {
-      method = 'GET',
+      method = "GET",
       url = buildedUrl,
       body = "",
-      headers = {{'Host', parsedUrl.host}}
+      headers = {{"Host", parsedUrl.host}}
     }
   end
 
-  describe('generateAndAuthenticatePreSignedUrl', function()
+  describe("generateAndAuthenticatePreSignedUrl", function()
 
     runTestFiles("generateAndAuthenticate", function(testFile, test)
       it("should validate the request " .. testFile, function()

--- a/spec/testsuite_spec.lua
+++ b/spec/testsuite_spec.lua
@@ -140,8 +140,8 @@ describe("Signer TestSuite", function()
       it("should return the proper string to sign " .. testFile, function()
         local config = getConfigFromTestsuite(test.config)
         local signer = Signer(config)
-        local date, secret = date(config.date), config.apiSecret
-        local stringToSign = signer:getStringToSign(test.request, test.headersToSign, date, secret)
+        local signDate, secret = date(config.date), config.apiSecret
+        local stringToSign = signer:getStringToSign(test.request, test.headersToSign, signDate, secret)
 
         if test.expected.stringToSign then
           assert.are.equals(test.expected.stringToSign, stringToSign)

--- a/spec/testsuite_spec.lua
+++ b/spec/testsuite_spec.lua
@@ -24,7 +24,7 @@ local function getConfigFromTestsuite(config)
 end
 
 local function runTestFiles(group, fn)
-  testFiles = {
+  local testFiles = {
     signing = {
       "spec/aws4_testsuite/signrequest-get-vanilla.json",
       "spec/aws4_testsuite/signrequest-post-vanilla.json",
@@ -112,7 +112,7 @@ describe("Escher TestSuite", function()
   describe("load 'GET vanilla' JSON", function()
 
     it("should properly loaded", function()
-      test = readTest("spec/aws4_testsuite/signrequest-get-vanilla.json")
+      local test = readTest("spec/aws4_testsuite/signrequest-get-vanilla.json")
       assert.are.equals(test.request.method, "GET")
     end)
 

--- a/spec/testsuite_spec.lua
+++ b/spec/testsuite_spec.lua
@@ -159,7 +159,7 @@ describe("Escher TestSuite", function()
         local escher = Escher:new(getConfigFromTestsuite(test.config))
         local authHeader = ""
 
-        test.request = escher:signRequest(test.request, test.headersToSign)
+        escher:signRequest(test.request, test.headersToSign)
 
         for _, element in ipairs(test.request.headers) do
           if element[1] == test.config.authHeaderName then

--- a/spec/testsuite_spec.lua
+++ b/spec/testsuite_spec.lua
@@ -119,7 +119,7 @@ describe("Canonicalizer TestSuite", function()
 
     runTestFiles("signing", function(testFile, test)
       it("should canonicalize the request " .. testFile, function()
-        local canonicalizer = Canonicalizer:new(getConfigFromTestsuite(test.config))
+        local canonicalizer = Canonicalizer(getConfigFromTestsuite(test.config))
         local canonicalizedRequest = canonicalizer:canonicalizeRequest(test.request, test.headersToSign)
 
         if test.expected.canonicalizedRequest then
@@ -139,7 +139,7 @@ describe("Signer TestSuite", function()
     runTestFiles("signing", function(testFile, test)
       it("should return the proper string to sign " .. testFile, function()
         local config = getConfigFromTestsuite(test.config)
-        local signer = Signer:new(config)
+        local signer = Signer(config)
         local date, secret = date(config.date), config.apiSecret
         local stringToSign = signer:getStringToSign(test.request, test.headersToSign, date, secret)
 
@@ -185,7 +185,7 @@ describe("Escher TestSuite", function()
 
     runTestFiles("signing", function(testFile, test)
       it("should generate full authorization header " .. testFile, function()
-        local escher = Escher:new(getConfigFromTestsuite(test.config))
+        local escher = Escher(getConfigFromTestsuite(test.config))
 
         local dateHeaderBeforeSign = findHeader(test.request, test.config.dateHeaderName)
 
@@ -210,7 +210,7 @@ describe("Escher TestSuite", function()
 
     runTestFiles("generateSignedUrl", function(testFile, test)
       it("should return the proper url string" .. testFile, function()
-        local escher = Escher:new(getConfigFromTestsuite(test.config))
+        local escher = Escher(getConfigFromTestsuite(test.config))
         local client = { test.config.accessKeyId, test.config.apiSecret }
         local signedUrl = escher:generatePreSignedUrl(test.request.url, client, test.request.expires)
 
@@ -238,7 +238,7 @@ describe("Escher TestSuite", function()
     runTestFiles("validation", function(testFile, test)
       it("should validate the request " .. testFile, function()
         local keyDb = makeKeyRetriever(test.keyDb)
-        local escher = Escher:new(getConfigFromTestsuite(test.config))
+        local escher = Escher(getConfigFromTestsuite(test.config))
         local apiKey, err = escher:authenticate(test.request, keyDb, test.mandatorySignedHeaders)
 
         if test.expected.apiKey then
@@ -284,7 +284,7 @@ describe("Escher TestSuite", function()
     runTestFiles("generateAndAuthenticate", function(testFile, test)
       it("should validate the request " .. testFile, function()
         local keyDb = makeKeyRetriever(test.keyDb)
-        local escher = Escher:new(getConfigFromTestsuite(test.config))
+        local escher = Escher(getConfigFromTestsuite(test.config))
         local client = { test.config.accessKeyId, test.config.apiSecret }
 
         test.request.url = escher:generatePreSignedUrl(test.request.url, client, test.request.expires)

--- a/spec/testsuite_spec.lua
+++ b/spec/testsuite_spec.lua
@@ -199,7 +199,7 @@ describe("Escher TestSuite", function()
     runTestFiles("generateSignedUrl", function(testFile, test)
       it("should return the proper url string" .. testFile, function()
         local escher = Escher:new(getConfigFromTestsuite(test.config))
-        local client = {test.config.accessKeyId, test.config.apiSecret}
+        local client = { test.config.accessKeyId, test.config.apiSecret }
         local signedUrl = escher:generatePreSignedUrl(test.request.url, client, test.request.expires)
 
         assert.are.equals(test.expected.url, signedUrl)
@@ -246,12 +246,12 @@ describe("Escher TestSuite", function()
 
   local function createRequestFromUrl(url)
     local parsedUrl = socketUrl.parse(url)
-    local buildedUrl = ""
+    local builtUrl = ""
     local enableBuild = false
 
-    for _,v in ipairs(socketUrl.parse_path(url)) do
+    for _, v in ipairs(socketUrl.parse_path(url)) do
       if enableBuild then
-        buildedUrl = buildedUrl .. "/" .. v
+        builtUrl = builtUrl .. "/" .. v
       elseif string.find(v, parsedUrl.host) ~= nil then
         enableBuild = true
       end
@@ -259,9 +259,11 @@ describe("Escher TestSuite", function()
 
     return {
       method = "GET",
-      url = buildedUrl,
+      url = builtUrl,
       body = "",
-      headers = {{"Host", parsedUrl.host}}
+      headers = {
+        { "Host", parsedUrl.host }
+      }
     }
   end
 

--- a/src/escher.lua
+++ b/src/escher.lua
@@ -2,6 +2,7 @@ local crypto = require("crypto")
 local date = require("date")
 local urlhandler = require("escher.urlhandler")
 local socketurl = require("socket.url")
+
 local Escher = {
   algoPrefix      = "ESR",
   vendorKey       = "ESCHER",
@@ -19,31 +20,35 @@ local function contains(table, element)
       return true
     end
   end
+
   return false
 end
 
-local function splitter(inputstr, sep)
-  if sep == nil then
-    sep = "%s"
-  end
-  local t={}
-  local i=1
-  for str in string.gmatch(inputstr, "([^"..sep.."]+)") do
-    t[i] = str
+local function split(str, separator)
+  separator = separator or "%s"
+
+  local pieces = {}
+  local i = 1
+
+  for str in string.gmatch(str, "([^" .. separator .. "]+)") do
+    pieces[i] = str
     i = i + 1
   end
-  return t
+
+  return pieces
 end
 
-function Escher:new(o)
-  o = o or {}
-  o.date = date(o.date or os.date("!%c"))
-  setmetatable(o, self)
-  self.__index = self
-  return o
+function Escher:new(options)
+  options = options or {}
+
+  options.date = date(options.date or os.date("!%c"))
+
+  setmetatable(options, {
+    __index = Escher
+  })
+
+  return options
 end
-
-
 
 function Escher:authenticate(request, getApiSecret, mandatorySignedHeaders)
   local uri = socketurl.parse(request.url)
@@ -53,15 +58,15 @@ function Escher:authenticate(request, getApiSecret, mandatorySignedHeaders)
   local authHeader = self:getHeader(request.headers, self.authHeaderName)
   local hostHeader = self:getHeader(request.headers, "host")
 
-  if dateHeader == nil and not isPresignedUrl then
+  if not dateHeader and not isPresignedUrl then
     return self.throwError("The " .. self.dateHeaderName:lower() .. " header is missing")
   end
 
-  if authHeader == nil and not isPresignedUrl then
+  if not authHeader and not isPresignedUrl then
     return self.throwError("The " .. self.authHeaderName:lower() .. " header is missing")
   end
 
-  if hostHeader == nil then
+  if not hostHeader then
     return self.throwError("The host header is missing")
   end
 
@@ -72,20 +77,20 @@ function Escher:authenticate(request, getApiSecret, mandatorySignedHeaders)
   if isPresignedUrl then
     requestDate = date(string.match(uri.query, "Date=([A-Za-z0-9]+)&"))
     authParts = self:parseQuery(socketurl.unescape(uri.query))
-    request.body = "UNSIGNED-PAYLOAD";
     expires = tonumber(string.match(uri.query, "Expires=([0-9]+)&"))
     request.url = self:canonicalizeUrl(request.url)
+    request.body = "UNSIGNED-PAYLOAD"
   else
     requestDate = date(dateHeader)
     authParts = self:parseAuthHeader(authHeader or "")
     expires = 0
   end
 
-  if authParts.hashAlgo == nil then
+  if not authParts.hashAlgo then
     return self.throwError("Could not parse " .. self.authHeaderName .. " header")
   end
 
-  local headersToSign = splitter(authParts.signedHeaders, ";")
+  local headersToSign = split(authParts.signedHeaders, ";")
 
   for _, header in ipairs(headersToSign) do
     if string.lower(header) ~= header then
@@ -93,7 +98,7 @@ function Escher:authenticate(request, getApiSecret, mandatorySignedHeaders)
     end
   end
 
-  if mandatorySignedHeaders == nil then
+  if not mandatorySignedHeaders then
     mandatorySignedHeaders = {}
   end
 
@@ -102,6 +107,7 @@ function Escher:authenticate(request, getApiSecret, mandatorySignedHeaders)
   end
 
   table.insert(mandatorySignedHeaders, "host")
+
   if not isPresignedUrl then
     table.insert(mandatorySignedHeaders, self.dateHeaderName:lower())
   end
@@ -110,6 +116,7 @@ function Escher:authenticate(request, getApiSecret, mandatorySignedHeaders)
     if type(header) ~= "string" then
       return self.throwError("The mandatorySignedHeaders parameter must be undefined or array of strings")
     end
+
     if not contains(headersToSign, header) then
       return self.throwError("The " ..  header .. " header is not signed")
     end
@@ -147,23 +154,20 @@ function Escher:authenticate(request, getApiSecret, mandatorySignedHeaders)
   return authParts.accessKeyId
 end
 
-
-
 function Escher:getHeader(headers, headerName)
-  local name
   for _, header in ipairs(headers) do
-    name = header[1]:lower():match("^%s*(.-)%s*$")
+    local name = header[1]:lower():match("^%s*(.-)%s*$")
+
     if name == headerName:lower() then
       return header[2]
     end
   end
 end
 
-
-
 function Escher:canonicalizeRequest(request, headersToSign)
-  local url = urlhandler.parse(request.url):normalize()
   headersToSign = self:addDefaultsToHeadersToSign(headersToSign)
+
+  local url = urlhandler.parse(request.url):normalize()
   local headers = self:filterHeaders(request.headers, headersToSign)
 
   return table.concat({
@@ -177,40 +181,42 @@ function Escher:canonicalizeRequest(request, headersToSign)
   }, "\n")
 end
 
-
-
 function Escher:canonicalizeHeaders(headers)
   local normalizedHeaders = {}
-  local name, value
+
   for _, header in ipairs(headers) do
-    name = header[1]:lower():match("^%s*(.-)%s*$")
+    local name = header[1]:lower():match("^%s*(.-)%s*$")
+
     if name ~= self.authHeaderName:lower() then
-      value = self:normalizeWhiteSpacesInHeaderValue(header[2])
+      local value = self:normalizeWhiteSpacesInHeaderValue(header[2])
       table.insert(normalizedHeaders, { name, value })
     end
   end
 
   local groupedHeaders = {}
-  local lastKey = false
+  local lastKey
+
   for _, header in ipairs(normalizedHeaders) do
     if lastKey == header[1] then
       groupedHeaders[#groupedHeaders] = string.format("%s,%s", groupedHeaders[#groupedHeaders], header[2])
     else
       table.insert(groupedHeaders, string.format("%s:%s", header[1], header[2]))
     end
+
     lastKey = header[1]
   end
 
   table.sort(groupedHeaders)
+
   return table.concat(groupedHeaders, "\n")
 end
 
-
-
 function Escher:canonicalizeSignedHeaders(headers, signedHeaders)
   local uniqueKeys = {}
+
   for _, header in pairs(headers) do
     local name = header[1]:lower()
+
     if name ~= self.authHeaderName:lower() then
       if (contains(signedHeaders, name) or name == self.dateHeaderName:lower() or name == "host") then
         uniqueKeys[name] = true
@@ -219,18 +225,17 @@ function Escher:canonicalizeSignedHeaders(headers, signedHeaders)
   end
 
   local normalizedKeys = {}
+
   for key, _ in pairs(uniqueKeys) do
     table.insert(normalizedKeys, key)
   end
 
   table.sort(normalizedKeys)
+
   return table.concat(normalizedKeys, ";")
 end
 
-
-
 function Escher:getStringToSign(request, headersToSign)
-
   return table.concat({
     string.format("%s-HMAC-%s", self.algoPrefix, self.hashAlgo),
     self:toLongDate(),
@@ -239,40 +244,41 @@ function Escher:getStringToSign(request, headersToSign)
   }, "\n")
 end
 
-
-
 function Escher:normalizeWhiteSpacesInHeaderValue(value)
   value = string.format(" %s ", value)
+
   local normalizedValue = {}
   local n = 0
+
   for part in string.gmatch(value, "[^\"]+") do
     n = n + 1
-    if n % 2 == 1 then part = part:gsub("%s+", " ") end
+
+    if n % 2 == 1 then
+      part = part:gsub("%s+", " ")
+    end
+
     table.insert(normalizedValue, part)
   end
+
   return table.concat(normalizedValue, "\""):match("^%s*(.-)%s*$")
 end
 
-
-
 function Escher:signRequest(request, headersToSign)
   local authHeader = self:generateHeader(request, headersToSign)
-  table.insert(request.headers, {self.authHeaderName, authHeader})
+
+  table.insert(request.headers, { self.authHeaderName, authHeader })
+
   return request
 end
-
-
 
 function Escher:generateHeader(request, headersToSign)
   request.headers = self:addDefaultToHeaders(request.headers)
 
   return self.algoPrefix .. "-HMAC-" .. self.hashAlgo ..
-          " Credential=" .. self:generateFullCredentials() ..
-          ", SignedHeaders=" .. self:canonicalizeSignedHeaders(request.headers, headersToSign) ..
-          ", Signature=" .. self:calculateSignature(request, headersToSign)
+    " Credential=" .. self:generateFullCredentials() ..
+    ", SignedHeaders=" .. self:canonicalizeSignedHeaders(request.headers, headersToSign) ..
+    ", Signature=" .. self:calculateSignature(request, headersToSign)
 end
-
-
 
 function Escher:calculateSignature(request, headersToSign)
   local stringToSign = self:getStringToSign(request, headersToSign)
@@ -285,14 +291,16 @@ function Escher:calculateSignature(request, headersToSign)
   return crypto.hmac.digest(self.hashAlgo, stringToSign, signingKey, false)
 end
 
-
-
 function Escher:parseAuthHeader(authHeader)
-  local hashAlgo, accessKeyId, shortDate, credentialScope, signedHeaders, signature = string.match(authHeader,
-    self.algoPrefix .. "%-HMAC%-(%w+)%s+" ..
-            "Credential=([A-Za-z0-9%-%_]+)/(%d+)/([A-Za-z0-9%-%_%/% ]-),%s*" ..
-            "SignedHeaders=([a-zA-Z0-9%-%_%;]+),%s*" ..
-            "Signature=([a-f0-9]+)")
+  local hashAlgo, accessKeyId, shortDate, credentialScope, signedHeaders, signature = string.match(
+    authHeader,
+    self.algoPrefix ..
+    "%-HMAC%-(%w+)%s+" ..
+    "Credential=([A-Za-z0-9%-%_]+)/(%d+)/([A-Za-z0-9%-%_%/% ]-),%s*" ..
+    "SignedHeaders=([a-zA-Z0-9%-%_%;]+),%s*" ..
+    "Signature=([a-f0-9]+)"
+  )
+
   return {
     hashAlgo = hashAlgo,
     accessKeyId = accessKeyId,
@@ -302,14 +310,13 @@ function Escher:parseAuthHeader(authHeader)
     signature = signature
   }
 end
-
-
 
 function Escher:parseQuery(query)
   local hashAlgo = string.match(query, self.algoPrefix .. "%-HMAC%-(%w+)&")
   local accessKeyId, shortDate, credentialScope = string.match(query, "Credentials=([A-Za-z0-9%-%_]+)/(%d+)/([A-Za-z0-9%-%_%/]-)&")
   local signedHeaders = string.match(query, "SignedHeaders=([a-z0-9%-%_%;]+)&")
   local signature = string.match(query, "Signature=([a-f0-9]+)")
+
   return {
     hashAlgo = hashAlgo,
     accessKeyId = accessKeyId,
@@ -320,32 +327,23 @@ function Escher:parseQuery(query)
   }
 end
 
-
-
 function Escher:toLongDate()
   return self.date:fmt("%Y%m%dT%H%M%SZ")
 end
-
-
 
 function Escher:toShortDate()
   return self.date:fmt("%Y%m%d")
 end
 
-
-
 function Escher:generateFullCredentials()
   return string.format("%s/%s/%s", self.accessKeyId, self:toShortDate(), self.credentialScope)
 end
 
+function Escher:isDateWithinRange(requestDate, expires)
+  local diff = math.abs(date.diff(self.date, requestDate):spanseconds())
 
-
-function Escher:isDateWithinRange(request_date, expires)
-  local diff = math.abs(date.diff(self.date, request_date):spanseconds())
   return diff <= self.clockSkew + expires
 end
-
-
 
 function Escher.throwError(error)
   return false, error
@@ -355,7 +353,7 @@ function Escher:filterHeaders(headers, headersToSign)
   local filteredHeaders = {}
   local fullHeadersToSign = headersToSign
 
-  for _, header in pairs(headers) do
+  for _, header in ipairs(headers) do
     if self.headerNeedToSign(header[1], fullHeadersToSign) then
       table.insert(filteredHeaders, header)
     end
@@ -365,25 +363,24 @@ function Escher:filterHeaders(headers, headersToSign)
 end
 
 function Escher.headerNeedToSign(headerName, headersToSign)
-  local enable = false
-  for _, header in pairs(headersToSign) do
+  for _, header in ipairs(headersToSign) do
     if headerName:lower() == header:lower() then
-      enable = true
+      return true
     end
   end
 
-  return enable
+  return false
 end
 
 function Escher:generatePreSignedUrl(url, client, expires)
-  if expires == nil then
-    expires = 86400
-  end
+  expires = expires or 86400
 
   local parsedUrl = socketurl.parse(socketurl.unescape(url))
   local host = parsedUrl.host
-  local headers = {{"host", host}}
-  local headersToSign = {"host"}
+  local headers = {
+    { "host", host }
+  }
+  local headersToSign = { "host" }
   local body = "UNSIGNED-PAYLOAD"
   local params = {
     Algorithm = self.algoPrefix .. "-HMAC-" .. self.hashAlgo,
@@ -392,8 +389,8 @@ function Escher:generatePreSignedUrl(url, client, expires)
     Expires = expires,
     SignedHeaders = headersToSign[1],
   }
-
   local hash = ""
+
   if parsedUrl.fragment ~= nil then
     hash = "#" .. parsedUrl.fragment
     parsedUrl.fragment = ""
@@ -401,11 +398,11 @@ function Escher:generatePreSignedUrl(url, client, expires)
   end
 
   local signedUrl = url .. "&" ..
-          "X-EMS-Algorithm=" .. params.Algorithm .. "&" ..
-          "X-EMS-Credentials=" .. params.Credentials .. "&" ..
-          "X-EMS-Date=" .. params.Date .. "&" ..
-          "X-EMS-Expires=" .. params.Expires .. "&" ..
-          "X-EMS-SignedHeaders=" .. params.SignedHeaders .. "&"
+    "X-EMS-Algorithm=" .. params.Algorithm .. "&" ..
+    "X-EMS-Credentials=" .. params.Credentials .. "&" ..
+    "X-EMS-Date=" .. params.Date .. "&" ..
+    "X-EMS-Expires=" .. params.Expires .. "&" ..
+    "X-EMS-SignedHeaders=" .. params.SignedHeaders .. "&"
 
   local parsedSignedUrl = socketurl.parse(signedUrl)
   local request = {
@@ -416,12 +413,12 @@ function Escher:generatePreSignedUrl(url, client, expires)
     body = body,
   }
   local signature = self:calculateSignature(request, headersToSign)
-  signedUrl = signedUrl .. "X-EMS-Signature=" .. signature  .. hash
-  return signedUrl
+
+  return signedUrl .. "X-EMS-Signature=" .. signature  .. hash
 end
 
 function Escher:canonicalizeUrl(url)
-  local splittedUrl = splitter(url, "&")
+  local splittedUrl = split(url, "&")
   local canonicalizedUrl = ""
 
   for _, value in ipairs(splittedUrl) do
@@ -443,7 +440,7 @@ function Escher:addDefaultToHeaders(headers)
   end
 
   if insertDate then
-    table.insert(headers, {self.dateHeaderName, self.date:fmt("${http}")})
+    table.insert(headers, { self.dateHeaderName, self.date:fmt("${http}") })
   end
 
   return headers

--- a/src/escher.lua
+++ b/src/escher.lua
@@ -38,6 +38,10 @@ local function split(str, separator)
   return pieces
 end
 
+local function trim(str)
+  return string.match(str, "^%s*(.-)%s*$")
+end
+
 function Escher:new(options)
   options = options or {}
 
@@ -156,7 +160,7 @@ end
 
 function Escher:getHeader(headers, headerName)
   for _, header in ipairs(headers) do
-    local name = header[1]:lower():match("^%s*(.-)%s*$")
+    local name = trim(header[1]:lower())
 
     if name == headerName:lower() then
       return header[2]
@@ -185,7 +189,7 @@ function Escher:canonicalizeHeaders(headers)
   local normalizedHeaders = {}
 
   for _, header in ipairs(headers) do
-    local name = header[1]:lower():match("^%s*(.-)%s*$")
+    local name = trim(header[1]:lower())
 
     if name ~= self.authHeaderName:lower() then
       local value = self:normalizeWhiteSpacesInHeaderValue(header[2])
@@ -260,7 +264,7 @@ function Escher:normalizeWhiteSpacesInHeaderValue(value)
     table.insert(normalizedValue, part)
   end
 
-  return table.concat(normalizedValue, "\""):match("^%s*(.-)%s*$")
+  return trim(table.concat(normalizedValue, "\""))
 end
 
 function Escher:signRequest(request, headersToSign)

--- a/src/escher.lua
+++ b/src/escher.lua
@@ -33,32 +33,6 @@ setmetatable(Escher, {
   __call = Escher.new
 })
 
-local function split(str, separator)
-  local pieces = {}
-  local i = 1
-
-  for matched in string.gmatch(str, "([^" .. separator .. "]+)") do
-    pieces[i] = matched
-    i = i + 1
-  end
-
-  return pieces
-end
-
-local function merge(target, ...)
-  if not target then return target end
-
-  for _, obj in pairs({...}) do
-    if obj then
-      for k, v in pairs(obj) do
-        target[k] = v
-      end
-    end
-  end
-
-  return target
-end
-
 local function getHeaderValue(headers, headerName)
   for _, header in ipairs(headers) do
     local name = utils.trim(header[1]:lower())
@@ -92,7 +66,7 @@ end
 local function canonicalizeUrl(url)
   local canonicalizedUrl = ""
 
-  for _, value in ipairs(split(url, "&")) do
+  for _, value in ipairs(utils.split(url, "&")) do
     if not string.match(value, "Signature") then
       canonicalizedUrl = canonicalizedUrl .. value .. "&"
     end
@@ -128,7 +102,7 @@ local function isDateWithinRange(requestDate, signedDate, expires)
 end
 
 function Escher:authenticate(request, getApiSecret, mandatorySignedHeaders)
-  request = merge({}, request)
+  request = utils.merge({}, request)
 
   local uri = socketurl.parse(request.url)
   local isPresignedUrl = string.match(uri.query or "", "Signature") and request.method == "GET"
@@ -169,7 +143,7 @@ function Escher:authenticate(request, getApiSecret, mandatorySignedHeaders)
     return throwError("Could not parse " .. self.authHeaderName .. " header")
   end
 
-  local headersToSign = split(authParts.signedHeaders, ";")
+  local headersToSign = utils.split(authParts.signedHeaders, ";")
 
   for _, header in ipairs(headersToSign) do
     if string.lower(header) ~= header then
@@ -181,7 +155,7 @@ function Escher:authenticate(request, getApiSecret, mandatorySignedHeaders)
     return throwError("The mandatorySignedHeaders parameter must be undefined or array of strings")
   end
 
-  mandatorySignedHeaders = merge({}, mandatorySignedHeaders)
+  mandatorySignedHeaders = utils.merge({}, mandatorySignedHeaders)
 
   table.insert(mandatorySignedHeaders, "host")
 
@@ -247,8 +221,8 @@ local function generateFullCredentials(self)
 end
 
 function Escher:generateHeader(request, headersToSign)
-  request = merge({}, request)
-  request.headers = merge({}, request.headers)
+  request = utils.merge({}, request)
+  request.headers = utils.merge({}, request.headers)
 
   addDateHeaderIfNotExists(self, request.headers)
 

--- a/src/escher.lua
+++ b/src/escher.lua
@@ -32,6 +32,10 @@ function Escher:new(options)
   return setmetatable(object, meta)
 end
 
+setmetatable(Escher, {
+  __call = Escher.new
+})
+
 local function split(str, separator)
   local pieces = {}
   local i = 1
@@ -127,7 +131,7 @@ local function isDateWithinRange(requestDate, signedDate, expires)
 end
 
 local function getStringToSign(self, request, headersToSign)
-  local canonicalizer = Canonicalizer:new(self)
+  local canonicalizer = Canonicalizer(self)
 
   return table.concat({
     self.algoPrefix .. "-HMAC-" .. self.hashAlgo,
@@ -276,7 +280,7 @@ function Escher:generateHeader(request, headersToSign)
 
   addDateHeaderIfNotExists(self, request.headers)
 
-  local canonicalizer = Canonicalizer:new(self)
+  local canonicalizer = Canonicalizer(self)
 
   return self.algoPrefix .. "-HMAC-" .. self.hashAlgo ..
     " Credential=" .. generateFullCredentials(self) ..

--- a/src/escher.lua
+++ b/src/escher.lua
@@ -149,6 +149,8 @@ local function calculateSignature(self, request, headersToSign)
 end
 
 function Escher:authenticate(request, getApiSecret, mandatorySignedHeaders)
+  request = merge({}, request)
+
   local uri = socketurl.parse(request.url)
   local isPresignedUrl = string.match(uri.query or "", "Signature") and request.method == "GET"
 

--- a/src/escher.lua
+++ b/src/escher.lua
@@ -55,6 +55,20 @@ local function trim(str)
   return string.match(str, "^%s*(.-)%s*$")
 end
 
+local function merge(target, ...)
+  if not target then return target end
+
+  for _, obj in pairs({...}) do
+    if obj then
+      for k, v in pairs(obj) do
+        target[k] = v
+      end
+    end
+  end
+
+  return target
+end
+
 local function getHeaderValue(headers, headerName)
   for _, header in ipairs(headers) do
     local name = trim(header[1]:lower())
@@ -182,13 +196,11 @@ function Escher:authenticate(request, getApiSecret, mandatorySignedHeaders)
     end
   end
 
-  if not mandatorySignedHeaders then
-    mandatorySignedHeaders = {}
-  end
-
-  if type(mandatorySignedHeaders) ~= "table" then
+  if type(mandatorySignedHeaders) ~= "table" and mandatorySignedHeaders ~= nil then
     return throwError("The mandatorySignedHeaders parameter must be undefined or array of strings")
   end
+
+  mandatorySignedHeaders = merge({}, mandatorySignedHeaders)
 
   table.insert(mandatorySignedHeaders, "host")
 

--- a/src/escher.lua
+++ b/src/escher.lua
@@ -414,8 +414,6 @@ function Escher:signRequest(request, headersToSign)
   local authHeader = self:generateHeader(request, headersToSign)
 
   table.insert(request.headers, { self.authHeaderName, authHeader })
-
-  return request
 end
 
 function Escher:generatePreSignedUrl(url, client, expires)

--- a/src/escher.lua
+++ b/src/escher.lua
@@ -26,7 +26,8 @@ local function splitter(inputstr, sep)
   if sep == nil then
     sep = "%s"
   end
-  local t={} ; i=1
+  local t={}
+  local i=1
   for str in string.gmatch(inputstr, "([^"..sep.."]+)") do
     t[i] = str
     i = i + 1
@@ -149,6 +150,7 @@ end
 
 
 function Escher:getHeader(headers, headerName)
+  local name
   for _, header in ipairs(headers) do
     name = header[1]:lower():match("^%s*(.-)%s*$")
     if name == headerName:lower() then
@@ -179,6 +181,7 @@ end
 
 function Escher:canonicalizeHeaders(headers)
   local normalizedHeaders = {}
+  local name, value
   for _, header in ipairs(headers) do
     name = header[1]:lower():match("^%s*(.-)%s*$")
     if name ~= self.authHeaderName:lower() then

--- a/src/escher.lua
+++ b/src/escher.lua
@@ -3,19 +3,31 @@ local date = require("date")
 local urlhandler = require("escher.urlhandler")
 local socketurl = require("socket.url")
 
-local Escher = {
-  algoPrefix      = "ESR",
-  vendorKey       = "ESCHER",
-  hashAlgo        = "SHA256",
-  credentialScope = "escher_request",
-  authHeaderName  = "X-Escher-Auth",
-  dateHeaderName  = "X-Escher-Date",
-  clockSkew       = 300,
-  date            = false
-}
-
 local LONG_DATE_FORMAT = "%Y%m%dT%H%M%SZ"
 local SHORT_DATE_FORMAT = "%Y%m%d"
+
+local Escher = {}
+
+Escher.__index = Escher
+
+function Escher:new(options)
+  options = options or {}
+
+  local object = {
+    algoPrefix = options.algoPrefix or "ESR",
+    vendorKey = options.vendorKey or "ESCHER",
+    hashAlgo = options.hashAlgo or "SHA256",
+    apiSecret = options.apiSecret,
+    accessKeyId = options.accessKeyId,
+    credentialScope = options.credentialScope or "escher_request",
+    authHeaderName = options.authHeaderName or "X-Escher-Auth",
+    dateHeaderName = options.dateHeaderName or "X-Escher-Date",
+    date = date(options.date or os.date("!%c")),
+    clockSkew = options.clockSkew or 300
+  }
+
+  return setmetatable(object, self)
+end
 
 local function contains(table, element)
   for _, value in pairs(table) do
@@ -41,18 +53,6 @@ end
 
 local function trim(str)
   return string.match(str, "^%s*(.-)%s*$")
-end
-
-function Escher:new(options)
-  options = options or {}
-
-  options.date = date(options.date or os.date("!%c"))
-
-  setmetatable(options, {
-    __index = Escher
-  })
-
-  return options
 end
 
 local function getHeaderValue(headers, headerName)

--- a/src/escher.lua
+++ b/src/escher.lua
@@ -3,12 +3,12 @@ local date = require("date")
 local urlhandler = require("escher.urlhandler")
 local socketurl = require("socket.url")
 local Escher = {
-  algoPrefix      = 'ESR',
-  vendorKey       = 'ESCHER',
-  hashAlgo        = 'SHA256',
-  credentialScope = 'escher_request',
-  authHeaderName  = 'X-Escher-Auth',
-  dateHeaderName  = 'X-Escher-Date',
+  algoPrefix      = "ESR",
+  vendorKey       = "ESCHER",
+  hashAlgo        = "SHA256",
+  credentialScope = "escher_request",
+  authHeaderName  = "X-Escher-Auth",
+  dateHeaderName  = "X-Escher-Date",
   clockSkew       = 300,
   date            = false
 }
@@ -46,11 +46,11 @@ end
 
 function Escher:authenticate(request, getApiSecret, mandatorySignedHeaders)
   local uri = socketurl.parse(request.url)
-  local isPresignedUrl = string.match(uri.query or '', "Signature") and request.method == 'GET'
+  local isPresignedUrl = string.match(uri.query or "", "Signature") and request.method == "GET"
 
   local dateHeader = self:getHeader(request.headers, self.dateHeaderName)
   local authHeader = self:getHeader(request.headers, self.authHeaderName)
-  local hostHeader = self:getHeader(request.headers, 'host')
+  local hostHeader = self:getHeader(request.headers, "host")
 
   if dateHeader == nil and not isPresignedUrl then
     return self.throwError("The " .. self.dateHeaderName:lower() .. " header is missing")
@@ -69,14 +69,14 @@ function Escher:authenticate(request, getApiSecret, mandatorySignedHeaders)
   local requestDate
 
   if isPresignedUrl then
-    requestDate = date(string.match(uri.query, 'Date=([A-Za-z0-9]+)&'))
+    requestDate = date(string.match(uri.query, "Date=([A-Za-z0-9]+)&"))
     authParts = self:parseQuery(socketurl.unescape(uri.query))
-    request.body = 'UNSIGNED-PAYLOAD';
-    expires = tonumber(string.match(uri.query, 'Expires=([0-9]+)&'))
+    request.body = "UNSIGNED-PAYLOAD";
+    expires = tonumber(string.match(uri.query, "Expires=([0-9]+)&"))
     request.url = self:canonicalizeUrl(request.url)
   else
     requestDate = date(dateHeader)
-    authParts = self:parseAuthHeader(authHeader or '')
+    authParts = self:parseAuthHeader(authHeader or "")
     expires = 0
   end
 
@@ -84,7 +84,7 @@ function Escher:authenticate(request, getApiSecret, mandatorySignedHeaders)
     return self.throwError("Could not parse " .. self.authHeaderName .. " header")
   end
 
-  local headersToSign = splitter(authParts.signedHeaders, ';')
+  local headersToSign = splitter(authParts.signedHeaders, ";")
 
   for _, header in ipairs(headersToSign) do
     if string.lower(header) ~= header then
@@ -96,17 +96,17 @@ function Escher:authenticate(request, getApiSecret, mandatorySignedHeaders)
     mandatorySignedHeaders = {}
   end
 
-  if type(mandatorySignedHeaders) ~= 'table' then
+  if type(mandatorySignedHeaders) ~= "table" then
     return self.throwError("The mandatorySignedHeaders parameter must be undefined or array of strings")
   end
 
-  table.insert(mandatorySignedHeaders, 'host')
+  table.insert(mandatorySignedHeaders, "host")
   if not isPresignedUrl then
     table.insert(mandatorySignedHeaders, self.dateHeaderName:lower())
   end
 
   for _, header in ipairs(mandatorySignedHeaders) do
-    if type(header) ~= 'string' then
+    if type(header) ~= "string" then
       return self.throwError("The mandatorySignedHeaders parameter must be undefined or array of strings")
     end
     if not contains(headersToSign, header) then
@@ -171,7 +171,7 @@ function Escher:canonicalizeRequest(request, headersToSign)
     self:canonicalizeHeaders(headers),
     "",
     self:canonicalizeSignedHeaders(headers, headersToSign),
-    crypto.digest(self.hashAlgo, request.body or '')
+    crypto.digest(self.hashAlgo, request.body or "")
   }, "\n")
 end
 
@@ -191,9 +191,9 @@ function Escher:canonicalizeHeaders(headers)
   local lastKey = false
   for _, header in ipairs(normalizedHeaders) do
     if lastKey == header[1] then
-      groupedHeaders[#groupedHeaders] = string.format('%s,%s', groupedHeaders[#groupedHeaders], header[2])
+      groupedHeaders[#groupedHeaders] = string.format("%s,%s", groupedHeaders[#groupedHeaders], header[2])
     else
-      table.insert(groupedHeaders, string.format('%s:%s', header[1], header[2]))
+      table.insert(groupedHeaders, string.format("%s:%s", header[1], header[2]))
     end
     lastKey = header[1]
   end
@@ -209,7 +209,7 @@ function Escher:canonicalizeSignedHeaders(headers, signedHeaders)
   for _, header in pairs(headers) do
     local name = header[1]:lower()
     if name ~= self.authHeaderName:lower() then
-      if (contains(signedHeaders, name) or name == self.dateHeaderName:lower() or name == 'host') then
+      if (contains(signedHeaders, name) or name == self.dateHeaderName:lower() or name == "host") then
         uniqueKeys[name] = true
       end
     end
@@ -229,9 +229,9 @@ end
 function Escher:getStringToSign(request, headersToSign)
 
   return table.concat({
-    string.format('%s-HMAC-%s', self.algoPrefix, self.hashAlgo),
+    string.format("%s-HMAC-%s", self.algoPrefix, self.hashAlgo),
     self:toLongDate(),
-    string.format('%s/%s', self:toShortDate(), self.credentialScope),
+    string.format("%s/%s", self:toShortDate(), self.credentialScope),
     crypto.digest(self.hashAlgo, self:canonicalizeRequest(request, headersToSign))
   }, "\n")
 end
@@ -242,12 +242,12 @@ function Escher:normalizeWhiteSpacesInHeaderValue(value)
   value = string.format(" %s ", value)
   local normalizedValue = {}
   local n = 0
-  for part in string.gmatch(value, '[^"]+') do
+  for part in string.gmatch(value, "[^\"]+") do
     n = n + 1
     if n % 2 == 1 then part = part:gsub("%s+", " ") end
     table.insert(normalizedValue, part)
   end
-  return table.concat(normalizedValue, '"'):match("^%s*(.-)%s*$")
+  return table.concat(normalizedValue, "\""):match("^%s*(.-)%s*$")
 end
 
 
@@ -379,36 +379,36 @@ function Escher:generatePreSignedUrl(url, client, expires)
 
   local parsedUrl = socketurl.parse(socketurl.unescape(url))
   local host = parsedUrl.host
-  local headers = {{'host', host}}
-  local headersToSign = {'host'}
-  local body = 'UNSIGNED-PAYLOAD'
+  local headers = {{"host", host}}
+  local headersToSign = {"host"}
+  local body = "UNSIGNED-PAYLOAD"
   local params = {
-    Algorithm = self.algoPrefix .. '-HMAC-' .. self.hashAlgo,
-    Credentials = string.gsub(client[1] .. '/' .. self:toShortDate() .. '/' .. self.credentialScope, '/', '%%2F'),
+    Algorithm = self.algoPrefix .. "-HMAC-" .. self.hashAlgo,
+    Credentials = string.gsub(client[1] .. "/" .. self:toShortDate() .. "/" .. self.credentialScope, "/", "%%2F"),
     Date = self:toLongDate(),
     Expires = expires,
     SignedHeaders = headersToSign[1],
   }
 
-  local hash = ''
+  local hash = ""
   if parsedUrl.fragment ~= nil then
-    hash = '#' .. parsedUrl.fragment
-    parsedUrl.fragment = ''
-    url = string.gsub(socketurl.build(parsedUrl), "#", '')
+    hash = "#" .. parsedUrl.fragment
+    parsedUrl.fragment = ""
+    url = string.gsub(socketurl.build(parsedUrl), "#", "")
   end
 
   local signedUrl = url .. "&" ..
-          "X-EMS-Algorithm=" .. params.Algorithm .. '&' ..
-          "X-EMS-Credentials=" .. params.Credentials .. '&' ..
-          "X-EMS-Date=" .. params.Date .. '&' ..
-          "X-EMS-Expires=" .. params.Expires .. '&' ..
-          "X-EMS-SignedHeaders=" .. params.SignedHeaders .. '&'
+          "X-EMS-Algorithm=" .. params.Algorithm .. "&" ..
+          "X-EMS-Credentials=" .. params.Credentials .. "&" ..
+          "X-EMS-Date=" .. params.Date .. "&" ..
+          "X-EMS-Expires=" .. params.Expires .. "&" ..
+          "X-EMS-SignedHeaders=" .. params.SignedHeaders .. "&"
 
   local parsedSignedUrl = socketurl.parse(signedUrl)
   local request = {
     host = host,
-    method = 'GET',
-    url = parsedSignedUrl.path .. '?' .. (parsedSignedUrl.query),
+    method = "GET",
+    url = parsedSignedUrl.path .. "?" .. (parsedSignedUrl.query),
     headers = headers,
     body = body,
   }
@@ -419,7 +419,7 @@ end
 
 function Escher:canonicalizeUrl(url)
   local splittedUrl = splitter(url, "&")
-  local canonicalizedUrl = ''
+  local canonicalizedUrl = ""
 
   for _, value in ipairs(splittedUrl) do
     if not string.match(value, "Signature") then
@@ -440,7 +440,7 @@ function Escher:addDefaultToHeaders(headers)
   end
 
   if insertDate then
-    table.insert(headers, {self.dateHeaderName, self.date:fmt('${http}')})
+    table.insert(headers, {self.dateHeaderName, self.date:fmt("${http}")})
   end
 
   return headers
@@ -451,8 +451,8 @@ function Escher:addDefaultsToHeadersToSign(headersToSign)
     table.insert(headersToSign, self.dateHeaderName)
   end
 
-  if not contains(headersToSign, 'Host') then
-    table.insert(headersToSign, 'Host')
+  if not contains(headersToSign, "Host") then
+    table.insert(headersToSign, "Host")
   end
 
   return headersToSign

--- a/src/escher.lua
+++ b/src/escher.lua
@@ -1,4 +1,3 @@
-local crypto = require("crypto")
 local date = require("date")
 local socketurl = require("socket.url")
 local utils = require("escher.utils")

--- a/src/escher.lua
+++ b/src/escher.lua
@@ -381,7 +381,7 @@ function Escher:getStringToSign(request, headersToSign)
   }, "\n")
 end
 
-local function addDefaultToHeaders(self, headers)
+local function addDateHeaderIfNotExists(self, headers)
   local insertDate = true
 
   for _, values in ipairs(headers) do
@@ -393,8 +393,6 @@ local function addDefaultToHeaders(self, headers)
   if insertDate then
     table.insert(headers, { self.dateHeaderName, self.date:fmt("${http}") })
   end
-
-  return headers
 end
 
 local function generateFullCredentials(self)
@@ -402,7 +400,10 @@ local function generateFullCredentials(self)
 end
 
 function Escher:generateHeader(request, headersToSign)
-  request.headers = addDefaultToHeaders(self, request.headers)
+  request = merge({}, request)
+  request.headers = merge({}, request.headers)
+
+  addDateHeaderIfNotExists(self, request.headers)
 
   return self.algoPrefix .. "-HMAC-" .. self.hashAlgo ..
     " Credential=" .. generateFullCredentials(self) ..

--- a/src/escher.lua
+++ b/src/escher.lua
@@ -401,7 +401,7 @@ local function generateFullCredentials(self)
   return string.format("%s/%s/%s", self.accessKeyId, self.date:fmt(SHORT_DATE_FORMAT), self.credentialScope)
 end
 
-local function generateHeader(self, request, headersToSign)
+function Escher:generateHeader(request, headersToSign)
   request.headers = addDefaultToHeaders(self, request.headers)
 
   return self.algoPrefix .. "-HMAC-" .. self.hashAlgo ..
@@ -411,7 +411,7 @@ local function generateHeader(self, request, headersToSign)
 end
 
 function Escher:signRequest(request, headersToSign)
-  local authHeader = generateHeader(self, request, headersToSign)
+  local authHeader = self:generateHeader(request, headersToSign)
 
   table.insert(request.headers, { self.authHeaderName, authHeader })
 

--- a/src/escher.lua
+++ b/src/escher.lua
@@ -13,7 +13,26 @@ local Escher = {
   date            = false
 }
 
+local function contains(table, element)
+  for _, value in pairs(table) do
+    if value:lower() == element:lower() then
+      return true
+    end
+  end
+  return false
+end
 
+local function splitter(inputstr, sep)
+  if sep == nil then
+    sep = "%s"
+  end
+  local t={} ; i=1
+  for str in string.gmatch(inputstr, "([^"..sep.."]+)") do
+    t[i] = str
+    i = i + 1
+  end
+  return t
+end
 
 function Escher:new(o)
   o = o or {}
@@ -90,7 +109,7 @@ function Escher:authenticate(request, getApiSecret, mandatorySignedHeaders)
     if type(header) ~= 'string' then
       return self.throwError("The mandatorySignedHeaders parameter must be undefined or array of strings")
     end
-    if not table.contains(headersToSign, header) then
+    if not contains(headersToSign, header) then
       return self.throwError("The " ..  header .. " header is not signed")
     end
   end
@@ -190,7 +209,7 @@ function Escher:canonicalizeSignedHeaders(headers, signedHeaders)
   for _, header in pairs(headers) do
     local name = header[1]:lower()
     if name ~= self.authHeaderName:lower() then
-      if (table.contains(signedHeaders, name) or name == self.dateHeaderName:lower() or name == 'host') then
+      if (contains(signedHeaders, name) or name == self.dateHeaderName:lower() or name == 'host') then
         uniqueKeys[name] = true
       end
     end
@@ -411,27 +430,6 @@ function Escher:canonicalizeUrl(url)
   return string.sub(canonicalizedUrl, 1, -2)
 end
 
-function splitter(inputstr, sep)
-  if sep == nil then
-    sep = "%s"
-  end
-  local t={} ; i=1
-  for str in string.gmatch(inputstr, "([^"..sep.."]+)") do
-    t[i] = str
-    i = i + 1
-  end
-  return t
-end
-
-function table.contains(table, element)
-  for _, value in pairs(table) do
-    if value:lower() == element:lower() then
-      return true
-    end
-  end
-  return false
-end
-
 function Escher:addDefaultToHeaders(headers)
   local insertDate = true
 
@@ -449,11 +447,11 @@ function Escher:addDefaultToHeaders(headers)
 end
 
 function Escher:addDefaultsToHeadersToSign(headersToSign)
-  if not table.contains(headersToSign, self.dateHeaderName) then
+  if not contains(headersToSign, self.dateHeaderName) then
     table.insert(headersToSign, self.dateHeaderName)
   end
 
-  if not table.contains(headersToSign, 'Host') then
+  if not contains(headersToSign, 'Host') then
     table.insert(headersToSign, 'Host')
   end
 

--- a/src/escher.lua
+++ b/src/escher.lua
@@ -414,6 +414,8 @@ end
 function Escher:signRequest(request, headersToSign)
   local authHeader = self:generateHeader(request, headersToSign)
 
+  addDateHeaderIfNotExists(self, request.headers)
+
   table.insert(request.headers, { self.authHeaderName, authHeader })
 end
 

--- a/src/escher.lua
+++ b/src/escher.lua
@@ -63,16 +63,16 @@ local function parseQuery(query, algoPrefix)
   }
 end
 
-local function canonicalizeUrl(url)
-  local canonicalizedUrl = ""
+local function stripSignatureFromQuery(url)
+  local strippedUrl = ""
 
   for _, value in ipairs(utils.split(url, "&")) do
     if not string.match(value, "Signature") then
-      canonicalizedUrl = canonicalizedUrl .. value .. "&"
+      strippedUrl = strippedUrl .. value .. "&"
     end
   end
 
-  return string.sub(canonicalizedUrl, 1, -2)
+  return string.sub(strippedUrl, 1, -2)
 end
 
 local function parseAuthHeader(authHeader, algoPrefix)
@@ -131,7 +131,7 @@ function Escher:authenticate(request, getApiSecret, mandatorySignedHeaders)
     requestDate = date(string.match(uri.query, "Date=([A-Za-z0-9]+)&"))
     authParts = parseQuery(socketurl.unescape(uri.query), self.algoPrefix)
     expires = tonumber(string.match(uri.query, "Expires=([0-9]+)&"))
-    request.url = canonicalizeUrl(request.url)
+    request.url = stripSignatureFromQuery(request.url)
     request.body = "UNSIGNED-PAYLOAD"
   else
     requestDate = date(dateHeader)

--- a/src/escher/canonicalizer.lua
+++ b/src/escher/canonicalizer.lua
@@ -1,0 +1,141 @@
+local crypto = require("crypto")
+local urlhandler = require("escher.urlhandler")
+local utils = require("escher.utils")
+
+local Canonicalizer = {}
+
+local meta = {
+  __index = Canonicalizer
+}
+
+function Canonicalizer:new(options)
+  local object = {
+    authHeaderName = options.authHeaderName,
+    dateHeaderName = options.dateHeaderName,
+    hashAlgo = options.hashAlgo
+  }
+
+  return setmetatable(object, meta)
+end
+
+local function addIfNotExists(headers, defaultHeaderName)
+  if not utils.contains(headers, defaultHeaderName) then
+    table.insert(headers, defaultHeaderName)
+  end
+end
+
+local function shouldSignHeader(headerName, headersToSign)
+  for _, header in ipairs(headersToSign) do
+    if headerName:lower() == header:lower() then
+      return true
+    end
+  end
+
+  return false
+end
+
+local function getHeadersToSign(headers, headersToSign)
+  local filteredHeaders = {}
+
+  for _, header in ipairs(headers) do
+    if shouldSignHeader(header[1], headersToSign) then
+      table.insert(filteredHeaders, header)
+    end
+  end
+
+  return filteredHeaders
+end
+
+local function normalizeWhiteSpacesInHeaderValue(value)
+  value = string.format(" %s ", value)
+
+  local normalizedValue = {}
+  local n = 0
+
+  for part in string.gmatch(value, "[^\"]+") do
+    n = n + 1
+
+    if n % 2 == 1 then
+      part = part:gsub("%s+", " ")
+    end
+
+    table.insert(normalizedValue, part)
+  end
+
+  return utils.trim(table.concat(normalizedValue, "\""))
+end
+
+local function canonicalizeHeaders(headers, authHeaderName)
+  local normalizedHeaders = {}
+
+  for _, header in ipairs(headers) do
+    local name = utils.trim(header[1]:lower())
+
+    if name ~= authHeaderName:lower() then
+      local value = normalizeWhiteSpacesInHeaderValue(header[2])
+
+      table.insert(normalizedHeaders, { name, value })
+    end
+  end
+
+  local groupedHeaders = {}
+  local lastKey
+
+  for _, header in ipairs(normalizedHeaders) do
+    if lastKey == header[1] then
+      groupedHeaders[#groupedHeaders] = string.format("%s,%s", groupedHeaders[#groupedHeaders], header[2])
+    else
+      table.insert(groupedHeaders, string.format("%s:%s", header[1], header[2]))
+    end
+
+    lastKey = header[1]
+  end
+
+  table.sort(groupedHeaders)
+
+  return table.concat(groupedHeaders, "\n")
+end
+
+function Canonicalizer:canonicalizeSignedHeaders(headers, signedHeaders)
+  local uniqueKeys = {}
+
+  for _, header in pairs(headers) do
+    local name = header[1]:lower()
+
+    if name ~= self.authHeaderName:lower() then
+      if utils.contains(signedHeaders, name) or name == self.dateHeaderName:lower() or name == "host" then
+        uniqueKeys[name] = true
+      end
+    end
+  end
+
+  local normalizedKeys = {}
+
+  for key, _ in pairs(uniqueKeys) do
+    table.insert(normalizedKeys, key)
+  end
+
+  table.sort(normalizedKeys)
+
+  return table.concat(normalizedKeys, ";")
+end
+
+function Canonicalizer:canonicalizeRequest(request, headersToSign)
+  addIfNotExists(headersToSign, self.dateHeaderName)
+  addIfNotExists(headersToSign, "Host")
+
+  local url = urlhandler.parse(request.url):normalize()
+  local headers = getHeadersToSign(request.headers, headersToSign)
+
+  return table.concat({
+    request.method,
+    url.path,
+    url.query,
+    canonicalizeHeaders(headers, self.authHeaderName),
+    "",
+    self:canonicalizeSignedHeaders(headers, headersToSign),
+    crypto.digest(self.hashAlgo, request.body or "")
+  }, "\n")
+end
+
+return Canonicalizer

--- a/src/escher/canonicalizer.lua
+++ b/src/escher/canonicalizer.lua
@@ -18,6 +18,10 @@ function Canonicalizer:new(options)
   return setmetatable(object, meta)
 end
 
+setmetatable(Canonicalizer, {
+  __call = Canonicalizer.new
+})
+
 local function addIfNotExists(headers, defaultHeaderName)
   if not utils.contains(headers, defaultHeaderName) then
     table.insert(headers, defaultHeaderName)

--- a/src/escher/signer.lua
+++ b/src/escher/signer.lua
@@ -1,6 +1,5 @@
 local crypto = require("crypto")
 local Canonicalizer = require("escher.canonicalizer")
-local urlhandler = require("escher.urlhandler")
 local utils = require("escher.utils")
 
 local Signer = {}

--- a/src/escher/signer.lua
+++ b/src/escher/signer.lua
@@ -1,0 +1,48 @@
+local crypto = require("crypto")
+local Canonicalizer = require("escher.canonicalizer")
+local urlhandler = require("escher.urlhandler")
+local utils = require("escher.utils")
+
+local Signer = {}
+
+local meta = {
+  __index = Signer
+}
+
+function Signer:new(options)
+  local object = {
+    authHeaderName = options.authHeaderName,
+    dateHeaderName = options.dateHeaderName,
+    credentialScope = options.credentialScope,
+    hashAlgo = options.hashAlgo,
+    algoPrefix = options.algoPrefix
+  }
+
+  return setmetatable(object, meta)
+end
+
+setmetatable(Signer, {
+  __call = Signer.new
+})
+
+function Signer:getStringToSign(request, headersToSign, date)
+  return table.concat({
+    self.algoPrefix .. "-HMAC-" .. self.hashAlgo,
+    utils.toLongDate(date),
+    utils.toShortDate(date) .. "/" .. self.credentialScope,
+    crypto.digest(self.hashAlgo, Canonicalizer(self):canonicalizeRequest(request, headersToSign))
+  }, "\n")
+end
+
+function Signer:calculateSignature(request, headersToSign, date, secret)
+  local stringToSign = self:getStringToSign(request, headersToSign, date, secret)
+  local signingKey = crypto.hmac.digest(self.hashAlgo, utils.toShortDate(date), self.algoPrefix .. secret, true)
+
+  for part in string.gmatch(self.credentialScope, "[A-Za-z0-9_\\-]+") do
+    signingKey = crypto.hmac.digest(self.hashAlgo, part, signingKey, true)
+  end
+
+  return crypto.hmac.digest(self.hashAlgo, stringToSign, signingKey, false)
+end
+
+return Signer

--- a/src/escher/signer.lua
+++ b/src/escher/signer.lua
@@ -33,13 +33,19 @@ function Signer:getStringToSign(request, headersToSign, date)
   }, "\n")
 end
 
-function Signer:calculateSignature(request, headersToSign, date, secret)
-  local stringToSign = self:getStringToSign(request, headersToSign, date, secret)
+local function getSigningKey(self, date, secret)
   local signingKey = crypto.hmac.digest(self.hashAlgo, utils.toShortDate(date), self.algoPrefix .. secret, true)
 
   for part in string.gmatch(self.credentialScope, "[A-Za-z0-9_\\-]+") do
     signingKey = crypto.hmac.digest(self.hashAlgo, part, signingKey, true)
   end
+
+  return signingKey
+end
+
+function Signer:calculateSignature(request, headersToSign, date, secret)
+  local stringToSign = self:getStringToSign(request, headersToSign, date, secret)
+  local signingKey = getSigningKey(self, date, secret)
 
   return crypto.hmac.digest(self.hashAlgo, stringToSign, signingKey, false)
 end

--- a/src/escher/utils.lua
+++ b/src/escher/utils.lua
@@ -1,4 +1,30 @@
 
+local function split(str, separator)
+  local pieces = {}
+  local i = 1
+
+  for matched in string.gmatch(str, "([^" .. separator .. "]+)") do
+    pieces[i] = matched
+    i = i + 1
+  end
+
+  return pieces
+end
+
+local function merge(target, ...)
+  if not target then return target end
+
+  for _, obj in pairs({...}) do
+    if obj then
+      for k, v in pairs(obj) do
+        target[k] = v
+      end
+    end
+  end
+
+  return target
+end
+
 local function contains(table, element)
   for _, value in pairs(table) do
     if value:lower() == element:lower() then
@@ -22,6 +48,8 @@ local function toShortDate(date)
 end
 
 return {
+  split = split,
+  merge = merge,
   contains = contains,
   trim = trim,
   toLongDate = toLongDate,

--- a/src/escher/utils.lua
+++ b/src/escher/utils.lua
@@ -1,0 +1,19 @@
+
+local function contains(table, element)
+  for _, value in pairs(table) do
+    if value:lower() == element:lower() then
+      return true
+    end
+  end
+
+  return false
+end
+
+local function trim(str)
+  return string.match(str, "^%s*(.-)%s*$")
+end
+
+return {
+  contains = contains,
+  trim = trim
+}

--- a/src/escher/utils.lua
+++ b/src/escher/utils.lua
@@ -13,7 +13,17 @@ local function trim(str)
   return string.match(str, "^%s*(.-)%s*$")
 end
 
+local function toLongDate(date)
+  return date:fmt("%Y%m%dT%H%M%SZ")
+end
+
+local function toShortDate(date)
+  return date:fmt("%Y%m%d")
+end
+
 return {
   contains = contains,
-  trim = trim
+  trim = trim,
+  toLongDate = toLongDate,
+  toShortDate = toShortDate
 }


### PR DESCRIPTION
Code and test refactor
Private methods no longer exposed as public
Removed global namespace pollution
Removed unwanted input parameter mutations from some public methods
Added authentication and request signing examples to readme